### PR TITLE
请修复滚动条未于顶部的时候产出的bug

### DIFF
--- a/src/wipe.js
+++ b/src/wipe.js
@@ -374,7 +374,7 @@ Wipe.prototype = {
         var cC = canvas.getBoundingClientRect();
         return {
             x: x - cC.left,
-            y: y - cC.top
+            y: y - cC.top - this.doc.body.scrollTop
         }
     },
     clear: function() {


### PR DESCRIPTION
滚动条非顶部，则发现涂沫位置不是在鼠标位置。查找原因是var cC = canvas.getBoundingClientRect();只会拿到canvas离浏览器顶部的距离，而非document顶部的距离。请作者修复一下。谢谢贡献代码！